### PR TITLE
Do not pollute global scope + other minor fixes.

### DIFF
--- a/jsml.js
+++ b/jsml.js
@@ -4,10 +4,11 @@
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
 (function($) {
-    var jsml = function(value) {
+    "use strict";
+    var jsml = function() {
         var el = jsml.dom.apply(this, arguments);
-        if (arguments.length == 1)
-            el = [el]
+        if (arguments.length === 1)
+            el = [el];
 
         this.empty();
 
@@ -21,13 +22,15 @@
 
     jsml.make = function (value) {
         return $(jsml.dom(value));
-    }
+    };
 
     jsml.dom = function (array) {
+        var i, j, l, $i, $l;
+
         if (arguments.length > 1) {
-            var results = []
-            for (var i=0; i<arguments.length; i++)
-                results[i] = jsml.dom(arguments[i])
+            var results = [];
+            for (i=0; i<arguments.length; i++)
+                results[i] = jsml.dom(arguments[i]);
             return results;
         }
 
@@ -41,17 +44,17 @@
             return document.createTextNode(array);
         var el = document.createElement(array[0]);
 
-        for (var i=1, l=array.length; i<l; i++) {
+        for (i=1, l=array.length; i<l; i++) {
             var a = array[i];
             if (!valid(a, array))
                 continue;
             if (a.constructor === Array) {
                 if (a.length === 0 || (a[0].constructor === Array || a[0].constructor === $ || typeof a[0].nodeType !== "undefined")) {
-                    for (var j in a) // [[],[],...] ==> [],[],...
+                    for (j in a) // [[],[],...] ==> [],[],...
                         if (a[j].constructor === Array)
-                            el.appendChild(jsml.dom(a[j]))
+                            el.appendChild(jsml.dom(a[j]));
                         else if (a[j].constructor === $)
-                            for ( var $i = 0, $l = a[j].length; $i < $l; $i++ )
+                            for ($i = 0, $l = a[j].length; $i < $l; $i++ )
                                 el.appendChild(a[j][$i]);
                         else if (typeof a[j].nodeType !== "undefined")
                             el.appendChild(a[j]);
@@ -61,13 +64,13 @@
             else if (typeof a.nodeType !== "undefined")
                 el.appendChild(a);
             else if (a.constructor === $)
-                for ( var $i = 0, $l = a.length; $i < $l; $i++ )
+                for ($i = 0, $l = a.length; $i < $l; $i++ )
                     el.appendChild(a[$i]);
             else if (a.constructor === Object)
                 for (var p in a) {
                     var ap = a[p];
                     if (valid(ap,a) && ap.constructor === Object)
-                        for (s in ap)
+                        for (var s in ap)
                             el[p][s] = ap[s];
                     else
                         el[p] = ap;
@@ -76,7 +79,7 @@
                 el.appendChild(document.createTextNode(a));
         }
         return el;
-    }
+    };
 
     $.fn.jsml = jsml;
 })(jQuery);

--- a/jsml.js
+++ b/jsml.js
@@ -4,8 +4,8 @@
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
 (function($) {
-    $.fn.jsml = function(value) {
-        var el = $.fn.jsml.dom.apply(this, arguments);
+    var jsml = function(value) {
+        var el = jsml.dom.apply(this, arguments);
         if (arguments.length == 1)
             el = [el]
 
@@ -19,15 +19,15 @@
         return this;
     };
 
-    $.fn.jsml.make = function (value) {
-        return $($.fn.jsml.dom(value));
+    jsml.make = function (value) {
+        return $(jsml.dom(value));
     }
 
-    $.fn.jsml.dom = function (array) {
+    jsml.dom = function (array) {
         if (arguments.length > 1) {
             var results = []
             for (var i=0; i<arguments.length; i++)
-                results[i] = $.fn.jsml.dom(arguments[i])
+                results[i] = jsml.dom(arguments[i])
             return results;
         }
 
@@ -49,14 +49,14 @@
                 if (a.length === 0 || (a[0].constructor === Array || a[0].constructor === $ || typeof a[0].nodeType !== "undefined")) {
                     for (var j in a) // [[],[],...] ==> [],[],...
                         if (a[j].constructor === Array)
-                            el.appendChild($.fn.jsml.dom(a[j]))
+                            el.appendChild(jsml.dom(a[j]))
                         else if (a[j].constructor === $)
                             for ( var $i = 0, $l = a[j].length; $i < $l; $i++ )
                                 el.appendChild(a[j][$i]);
                         else if (typeof a[j].nodeType !== "undefined")
                             el.appendChild(a[j]);
                 } else
-                    el.appendChild($.fn.jsml.dom(a));
+                    el.appendChild(jsml.dom(a));
             }
             else if (typeof a.nodeType !== "undefined")
                 el.appendChild(a);
@@ -77,4 +77,6 @@
         }
         return el;
     }
+
+    $.fn.jsml = jsml;
 })(jQuery);


### PR DESCRIPTION
Original jshint report (for the base branch):

```
$ jshint jsml.js 
jsml.js: line 10, col 22, Missing semicolon.
jsml.js: line 24, col 6, Missing semicolon.
jsml.js: line 28, col 29, Missing semicolon.
jsml.js: line 30, col 57, Missing semicolon.
jsml.js: line 44, col 19, 'i' is already defined.
jsml.js: line 52, col 64, Missing semicolon.
jsml.js: line 64, col 30, '$i' is already defined.
jsml.js: line 64, col 38, '$l' is already defined.
jsml.js: line 70, col 30, Creating global 'for' variable. Should be 'for (var s ...'.
jsml.js: line 79, col 6, Missing semicolon.

10 errors
```

Extra info:
```
jsml.js :
        Implied globals:
                document: 41,42,76
                s: 71,71
                jQuery: 80
        Unused Variables:
                value(7), 
```


«var jsml» makes the code a little cleaner.