### PR TITLE
Extensible

### DIFF
--- a/jsml.js
+++ b/jsml.js
@@ -20,6 +20,8 @@
         return this;
     };
 
+    jsml.elements = {};
+
     jsml.make = function (value) {
         return $(jsml.dom(value));
     };
@@ -42,6 +44,19 @@
         };
         if (array.constructor === String)
             return document.createTextNode(array);
+
+        if (jsml.elements.hasOwnProperty(array[0])) {
+            var ex = jsml.elements[array[0]](array);
+            if (ex.constructor === Array)
+                return jsml.dom(ex);
+            else if (typeof ex.nodeType !== "undefined")
+                return ex;
+            else if ((ex.constructor === $) && (ex.length >= 1))
+                return ex[0];
+            else
+                return document.createTextNode(ex);
+        }
+
         var el = document.createElement(array[0]);
 
         for (i=1, l=array.length; i<l; i++) {


### PR DESCRIPTION
This includes #2.

The only change from #2 is introduction of the `$.fn.jsml.elements` object that allows for users to define own element types.

A (very) simple example:

``` javascript
$.fn.jsml.elements.timeago = function(arr) {
    return $.fn.jsml.make(['abbr', {title: arr[1].date.toISOString()}]).timeago();
};
```

allows using `['timeago', {date: arg.created}]` instead of `['abbr', {className: 'timeago', title: item.date.toISOString()}]` and manual calls to `$('.timeago').timeago().removeClass('timeago')`.

In a more complex example, this:

``` javascript
['div', {className: 'btn-group', dataset: {toggle: 'buttons', formAttr: 'type'}},
 ['label', {className: 'btn btn-sm btn-default type-all'},
   ['input', {type: 'radio', value: 'all'}],
   ['i', {className: 'fa fa-file-o fa-fw'}],
   ' '
 ],
 ['label', {className: 'btn btn-sm btn-default type-text'},
   ['input', {type: 'radio', value: 'text'}],
   ['i', {className: 'fa fa-file-text-o fa-fw'}],
   ' '
 ],
 ['label', {className: 'btn btn-sm btn-default type-photo'},
   ['input', {type: 'radio', value: 'photo'}],
   ['i', {className: 'fa fa-picture-o fa-fw'}],
   ' '
 ],
 ['label', {className: 'btn btn-sm btn-default type-video'},
   ['input', {type: 'radio', value: 'video'}],
   ['i', {className: 'fa fa-film fa-fw'}],
   ' '
 ],
],
```

gets replaced by this:

``` javascript
['option-group', {formAttr: 'type', size: 'sm'},
 ['option', {value: 'all', className: 'type-all', icon: 'fa-file-o'}],
 ['option', {value: 'text', className: 'type-text', icon: 'fa-file-text-o'}],
 ['option', {value: 'photo', className: 'type-photo', icon: 'fa-picture-o'}],
 ['option', {value: 'video', className: 'type-video', icon: 'fa-film'}]
],
```
